### PR TITLE
Ref issue #14 Include the missing files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setuptools.setup(
     url="https://github.com/SoftwareQuTech/CQC-Python",
     include_package_data=True,
     packages=setuptools.find_packages(),
+    data_files=[('./', ['requirements.txt'])],
     install_requires=install_requires,
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This pull request is trying to fix the issue https://github.com/SoftwareQuTech/CQC-Python/issues/14 by including the non-package data files. The previous release (cqc v3.0.1) seems to be published to PyPI in the wheel format so we did not have the issue.

There are 3 kinds of solutions to fix the issue. They are

1. include the expected non-package data files (this pull request)
2. use MANIFEST
3. publish the package in wheel format

This pull request adopts the 1st solution because
1. the original code use the requirements.txt-reading trick rather than MANIFEST. I followed the orignial coding logistic.
2. I have not been familiar with the whole project enough to enumerate all necessary files to the MANIFEST. A smaller but more reliable step is to refactor the code base by following the original coding logistic. We could migrate to MANIFEST later if necessary, e.g. the project is getting larger and larger.


# Verification

The following test cases are performed and look good (tested along with this simulaqron pr https://github.com/SoftwareQuTech/SimulaQron/pull/204 ) :

- [x] install the `python setup.py sdist` tarball
- [x] simulaqron.tests()
- [x] corrRNG example